### PR TITLE
Kafka 7514 - Trogdor support multiple consumers in ConsumeBenchWorker

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/CollectionUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CollectionUtils.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.util.stream.IntStream.range;
+
 public final class CollectionUtils {
 
     private CollectionUtils() {}
@@ -35,6 +37,23 @@ public final class CollectionUtils {
         return minuend.entrySet().stream()
                 .filter(entry -> !subtrahend.containsKey(entry.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Splits a #{@link List} into #{@code listsCount} #{@link List} instances,
+     * splitting the elements in a round-robin fashion.
+     *
+     * Example:
+     * splitListRoundRobin([1, 2, 3, 4, 5], 3)
+     *  -> [[1, 4], [2, 5], [3]]
+     *
+     */
+    public static <T> List<List<T>> splitListRoundRobin(List<T> collection, int listsCount) {
+        List<List<T>> splitLists = range(0, listsCount).mapToObj(i -> new ArrayList<T>()).collect(Collectors.toList());
+        for (int i = 0; i < collection.size(); i++) {
+            splitLists.get(i % listsCount).add(collection.get(i));
+        }
+        return splitLists;
     }
 
     /**

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchSpec.java
@@ -61,6 +61,11 @@ import java.util.HashSet;
  * #{@link org.apache.kafka.clients.consumer.KafkaConsumer#subscribe(Collection)}.
  * It will be assigned partitions dynamically from the consumer group.
  *
+ * This specification supports the spawning of multiple consumers in the single Trogdor worker agent.
+ * The "consumeCount" field denotes how many consumers should be spawned for this spec.
+ * It is worth nothing that the "targetMessagesPerSec" and "maxMessages" fields apply for every consumer individually,
+ * whereas "activeTopics" will get assigned to every consumer in a round-robin fashion
+ *
  * An example JSON representation which will result in a consumer that is part of the consumer group "cg" and
  * subscribed to topics foo1, foo2, foo3 and bar.
  * #{@code
@@ -88,6 +93,7 @@ public class ConsumeBenchSpec extends TaskSpec {
     private final Map<String, String> commonClientConf;
     private final List<String> activeTopics;
     private final String consumerGroup;
+    private final int consumerCount;
 
     @JsonCreator
     public ConsumeBenchSpec(@JsonProperty("startMs") long startMs,
@@ -100,6 +106,7 @@ public class ConsumeBenchSpec extends TaskSpec {
                             @JsonProperty("consumerConf") Map<String, String> consumerConf,
                             @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
                             @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
+                            @JsonProperty("consumerCount") Integer consumerCount,
                             @JsonProperty("activeTopics") List<String> activeTopics) {
         super(startMs, durationMs);
         this.consumerNode = (consumerNode == null) ? "" : consumerNode;
@@ -111,6 +118,7 @@ public class ConsumeBenchSpec extends TaskSpec {
         this.adminClientConf = configOrEmptyMap(adminClientConf);
         this.activeTopics = activeTopics == null ? new ArrayList<>() : activeTopics;
         this.consumerGroup = consumerGroup == null ? EMPTY_CONSUMER_GROUP : consumerGroup;
+        this.consumerCount = consumerCount == null ? 1 : consumerCount;
     }
 
     @JsonProperty
@@ -136,6 +144,11 @@ public class ConsumeBenchSpec extends TaskSpec {
     @JsonProperty
     public int maxMessages() {
         return maxMessages;
+    }
+
+    @JsonProperty
+    public int consumerCount() {
+        return consumerCount;
     }
 
     @JsonProperty


### PR DESCRIPTION
This PR adds a new ConsumeBenchSpec field - `"consumerCount"`. "consumerCount" will be spawned over "consumerCount" threads in the ConsumeBenchWorker.

It's now questionable how existing fields such as "targetMessagesPerSec", "maxMessages", "consumerGroup" and "activeTopics" should work.

With `"activeTopics"`, we need to decide whether they should be split over the consumers or not.
I see 4 cases which I believe we should address like this:
1. Random group, subscribe to topics - N unique groups all subscribed to all topics
2. Specific group, subscribe to topics - 1 group subscribed to all topics. Consumers share workload.
3. Random groups, assign partitions - X groups all subscribed to all partitions
4. Specific group, assign partitions - 1 group all subscribed to part of the partitions (split in a round-robin style)

I believe `"targetMessagesPerSec", "maxMessages"` should account for each consumer individually. This would ease implementation by a ton, too.

Since `"consumerCount"` will be 1 by default, these changes are backwards compatible